### PR TITLE
Fix no date or no time string converted to DateTime

### DIFF
--- a/br2dl/time_parser.py
+++ b/br2dl/time_parser.py
@@ -6,10 +6,14 @@ from dateutil.tz import tzutc
 import re
 
 NanosecPattern = re.compile(r".+\.(\d+).*")
+RequiredTimePattern = re.compile(r".*\d\d?[/:-]\d\d?.*")
 
 def elastic_time_parse(src, logger = None):
     """Parse src string as datetime and nanosec part. Raise exception if src format is NOT valid. """
     nano = 0
+
+    if not re.match(RequiredTimePattern, src):
+        raise ValueError
 
     ret = parse(src)
     if ret.tzinfo == None:

--- a/tests/test_time_parser.py
+++ b/tests/test_time_parser.py
@@ -83,5 +83,9 @@ def test_return_Time_value_if_string_is_Time_like_format_without_zero_padding():
                     datetime(2018, 11, 14, 9, 6, 0, 0 * 1000, timezone(timedelta(hours=0))), 0
                     )
 
+def test_return_original_string_is_simple_day_of_week():
+    assertNotValid("Sat")
+
+
 if __name__ == '__main__':
     pytest.main(['-v', __file__])


### PR DESCRIPTION
For example, "Sun" is converted to DateTime sunday 00:00 in this week, unexpected.