### PR TITLE
Fix local-source-settings-file commandline argument in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,7 +81,7 @@ ENTRYPOINT python ./grebe.py ${MQ_QNAME} \
     -dh ${DB_HOST} -dp ${DB_PORT} \
     --schema-store ${SCHEMA_STORE}\
     --local-schema-dir ${LOCAL_SCHEMA_DIR}\
-    --local-source-settings-file ${LOCAL_SOURCE_SETTINGS_FILE}\
+    --local-source-settings-file "${LOCAL_SOURCE_SETTINGS_FILE}" \
     --tz "${TZ_STR}" \
     --api-port ${API_PORT} \
     --log-level ${LOG_LEVEL} \


### PR DESCRIPTION
It is used local file when local_source_setting_file argument is not provided.